### PR TITLE
Improve README and other instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,6 @@ https://github.com/discourse/discourse/blob/master/docs/code-of-conduct.md ?
 
 ## ThoughtWork's role
 
-ThoughtWorks seeds the community that builds CoyIM. We seed the development, investing our own resources: We provide a team of software delivery experts to lay the foundation for the project. We use our network and contacts to approach customers and users.
+ThoughtWorks started the development of CoyIM on October 2015. The company invested its own resources and provided a team of software delivery experts to lay the foundation for the project.
 
-ThoughtWorks started building CoyIM because it is right. In combining our passion for defending a free internet and our capability to deliver software, we build software to counter widespread mass surveillance of email communication.
-
-It is not ThoughWork's goal to make money from CoyIM. The reasons are multiple, but at the end of the day, we believe that our goals of ensuring digital privacy and anonymity for every person on the planet can best be achieved if CoyIM puts end users before a revenue stream.
-
+The goal wasn't to make money from CoyIM, but to combine our capability to deliver software and our passion for defending a free Internet. We want to build software to counter widespread mass surveillance and ensure digital privacy and anonymity for every person on the planet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,4 +88,4 @@ https://github.com/discourse/discourse/blob/master/docs/code-of-conduct.md ?
 
 ThoughtWorks started the development of CoyIM on October 2015. The company invested its own resources and provided a team of software delivery experts to lay the foundation for the project.
 
-The goal wasn't to make money from CoyIM, but to combine our capability to deliver software and our passion for defending a free Internet. We want to build software to counter widespread mass surveillance and ensure digital privacy and anonymity for every person on the planet.
+ThoughtWork's goal wasn't to make money from CoyIM, but to combine their capability to deliver software and passion for defending a free Internet. Since then, we wanted to build software to counter the widespread of mass surveillance, and ensure digital privacy and anonymity for every person on the planet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Here's the brief:
   * Email: [coyim@olabini.se](mailto:coyim@olabini.se)
   * Twitter: [@coyproject](https://twitter.com/coyproject)
 
-  This document outlines our way of working, gives hints and outlines the steps to make your contribution to Coy IM as smooth as possible. You're not required to read this before getting started. We're explaining the way we work to make sure you're having a good experience and can make best use of the time you're contributing to our project.
+  This document outlines our way of working, gives hints and outlines the steps to make your contribution to CoyIM as smooth as possible. You're not required to read this before getting started. We're explaining the way we work to make sure you're having a good experience and can make best use of the time you're contributing to our project.
 
 ## Getting started
 
@@ -86,9 +86,9 @@ https://github.com/discourse/discourse/blob/master/docs/code-of-conduct.md ?
 
 ## ThoughtWork's role
 
-ThoughtWorks seeds the community that builds Coy IM. We seed the development, investing our own resources: We provide a team of software delivery experts to lay the foundation for the project. We use our network and contacts to approach customers and users.
+ThoughtWorks seeds the community that builds CoyIM. We seed the development, investing our own resources: We provide a team of software delivery experts to lay the foundation for the project. We use our network and contacts to approach customers and users.
 
-ThoughtWorks started building Coy IM because it is right. In combining our passion for defending a free internet and our capability to deliver software, we build software to counter widespread mass surveillance of email communication.
+ThoughtWorks started building CoyIM because it is right. In combining our passion for defending a free internet and our capability to deliver software, we build software to counter widespread mass surveillance of email communication.
 
-It is not ThoughWork's goal to make money from Coy IM. The reasons are multiple, but at the end of the day, we believe that our goals of ensuring digital privacy and anonymity for every person on the planet can best be achieved if Coy IM puts end users before a revenue stream.
+It is not ThoughWork's goal to make money from CoyIM. The reasons are multiple, but at the end of the day, we believe that our goals of ensuring digital privacy and anonymity for every person on the planet can best be achieved if CoyIM puts end users before a revenue stream.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Coverage Status](https://coveralls.io/repos/coyim/coyim/badge.svg?branch=master&service=github)](https://coveralls.io/github/coyim/coyim?branch=master)
 [![Download](https://api.bintray.com/packages/coyim/coyim-bin/coyim-bin/images/download.svg)](https://bintray.com/coyim/coyim-bin/coyim-bin/_latestVersion#files)
 
-CoyIM is a new client for the XMPP protocol. It is built upon https://github.com/agl/xmpp-client and https://github.com/coyim/otr3. It adds a graphical user interface and tries to be safe and secure by default. Our ambition is that it should be possible for even the most high-risk people on the planet to safely use CoyIM, without having to make any configuration changes.
+CoyIM is a new client for the XMPP protocol. It is built upon https://github.com/agl/xmpp-client and https://github.com/coyim/otr3. It adds a graphical user interface and implies safe and secure options by default. Our ambition is that it should be possible for even the most high-risk people on the planet to safely use CoyIM, without having to make any configuration changes.
 
-To do this, we enable OTR by default, we default to use Tor and we will use the Tor Onion Service for a server if we know it, and also to use TLS and TLS certificates to verify the connection - no configuration necessary. The implementation is written in the Go language, to avoid many common types of vulnerabilities that come from using unsafe languages.
+To do this, CoyIM has OTR enabled and uses Tor by default. Besides that, it will only use the Tor Onion Service for a known server and also uses TLS and TLS certificates to verify the connection - no configuration required. The implementation is written in the Go language, to avoid many common types of vulnerabilities that come from using unsafe languages.
 
 ## Security warning
 
@@ -66,4 +66,3 @@ We have instructions to help you [get started contributing to CoyIM](CONTRIBUTIN
 ## Reproducibility
 
 CoyIM supports reproducible builds for Linux on AMD64. See [REPRODUCIBILITY](REPRODUCIBILITY.md) for instructions on how to build or verify these builds.
-

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ Instructions for creating a release
 ```sh
     git push origin v0.x.y
 ```
-- Add release notes to the tag on Github
+- Add release notes to the tag on GitHub
 - Wait for Travis to finish building and publishing all binaries to Bintray
 - Create a new blog post on coyim-pages with the release notes
 - Update the config on coyim-pages to make the new version the current release

--- a/config/importer/adium_test_data/libpurple/accounts.xml
+++ b/config/importer/adium_test_data/libpurple/accounts.xml
@@ -289,7 +289,7 @@
 		</statuses>
 		<userinfo></userinfo>
 		<settings>
-			<setting name='display-name' type='string'>Coy IM</setting>
+			<setting name='display-name' type='string'>CoyIM</setting>
 			<setting name='buddy_icon_timestamp' type='int'>12312312312</setting>
 			<setting name='endpoint-name' type='string'>Adium</setting>
 			<setting name='custom_smileys' type='bool'>1</setting>

--- a/gui/ui.go
+++ b/gui/ui.go
@@ -601,7 +601,7 @@ func (u *gtkUI) shouldViewAccounts() bool {
 
 func (u *gtkUI) aboutDialog() {
 	dialog, _ := g.gtk.AboutDialogNew()
-	dialog.SetName(i18n.Local("Coy IM!"))
+	dialog.SetName(i18n.Local("CoyIM!"))
 	dialog.SetProgramName(programName)
 	dialog.SetAuthors(authors())
 	dialog.SetVersion(coyimVersion)

--- a/i18n/ar/LC_LC_MESSAGES/coy.po
+++ b/i18n/ar/LC_LC_MESSAGES/coy.po
@@ -683,7 +683,7 @@ msgid "%s wants to talk to you. Is that ok?"
 msgstr ""
 
 #: ../gui/ui.go:427
-msgid "Coy IM!"
+msgid "CoyIM!"
 msgstr ""
 
 #: ../gui/ui.go:453

--- a/i18n/coy.pot
+++ b/i18n/coy.pot
@@ -684,7 +684,7 @@ msgid "%s wants to talk to you. Is that ok?"
 msgstr ""
 
 #: ../gui/ui.go:427
-msgid "Coy IM!"
+msgid "CoyIM!"
 msgstr ""
 
 #: ../gui/ui.go:453

--- a/i18n/en_US/LC_MESSAGES/coy.po
+++ b/i18n/en_US/LC_MESSAGES/coy.po
@@ -712,8 +712,8 @@ msgid "%s wants to talk to you. Is that ok?"
 msgstr "%s wants to talk to you. Is that ok?"
 
 #: ../gui/ui.go:427
-msgid "Coy IM!"
-msgstr "Coy IM!"
+msgid "CoyIM!"
+msgstr "CoyIM!"
 
 #: ../gui/ui.go:453
 msgid "There is no account with the id %q"

--- a/i18n/es_EC/LC_MESSAGES/coy.po
+++ b/i18n/es_EC/LC_MESSAGES/coy.po
@@ -427,7 +427,7 @@ msgid "trusted"
 msgstr ""
 
 #: ../gui/ui.go:427
-msgid "Coy IM!"
+msgid "CoyIM!"
 msgstr ""
 
 #: ../gui/ui.go:453

--- a/i18n/pt_BR/LC_MESSAGES/coy.po
+++ b/i18n/pt_BR/LC_MESSAGES/coy.po
@@ -685,7 +685,7 @@ msgid "%s wants to talk to you. Is that ok?"
 msgstr ""
 
 #: ../gui/ui.go:427
-msgid "Coy IM!"
+msgid "CoyIM!"
 msgstr ""
 
 #: ../gui/ui.go:453

--- a/i18n/sv_SE/LC_MESSAGES/coy.po
+++ b/i18n/sv_SE/LC_MESSAGES/coy.po
@@ -685,7 +685,7 @@ msgid "%s wants to talk to you. Is that ok?"
 msgstr ""
 
 #: ../gui/ui.go:427
-msgid "Coy IM!"
+msgid "CoyIM!"
 msgstr ""
 
 #: ../gui/ui.go:453

--- a/i18n/zh_CN/LC_MESSAGES/coy.po
+++ b/i18n/zh_CN/LC_MESSAGES/coy.po
@@ -697,7 +697,7 @@ msgid "%s wants to talk to you. Is that ok?"
 msgstr "%s想要与您建立联系，是否同意？"
 
 #: ../gui/ui.go:427
-msgid "Coy IM!"
+msgid "CoyIM!"
 msgstr ""
 
 #: ../gui/ui.go:453


### PR DESCRIPTION
This PR has the following changes:

- Improve a little bit the wording on README;
- Update TW's role section;
- Standardize project name as CoyIM (single word). I'm not sure if that would break the i18n sync though.
Let me know if i18n should be kept or changed somewhere else;