### PR TITLE
Replace references to deps-dev make rule with deps

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ environment:
 install:
   - .\ci\install-deps-windows.bat
 build_script:
-  - '%MSYS_PATH%\usr\bin\bash -lc "cd /c/gopath/src/github.com/coyim/coyim && make deps-dev"'
+  - '%MSYS_PATH%\usr\bin\bash -lc "cd /c/gopath/src/github.com/coyim/coyim && make deps"'
   - '%MSYS_PATH%\usr\bin\bash -lc "cd /c/gopath/src/github.com/coyim/coyim && make build-gui-win"'
 after_build:
   - .\ci\build-windows-bundle.bat

--- a/development/Makefile
+++ b/development/Makefile
@@ -11,7 +11,7 @@ check: lint test
 autogen: gen-ui-defs gen-schema-defs
 
 check-deps:
-	@type esc >/dev/null 2>&1 || (echo "The program 'esc' is required but not available. Please install it by running 'make deps-dev'." && exit 1)
+	@type esc >/dev/null 2>&1 || (echo "The program 'esc' is required but not available. Please install it by running 'make deps'." && exit 1)
 
 gen-ui-defs: check-deps
 	make -C ../gui


### PR DESCRIPTION
It don't exist!
```
make: *** No rule to make target 'deps-dev'.  Stop.
```