### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/roster/peer.go
+++ b/roster/peer.go
@@ -236,7 +236,7 @@ func (p *Peer) ClearResources() {
 	p.resources = make(map[string]Status)
 }
 
-// LastResource sets the last resource used
+// LastSeen sets the last resource used
 func (p *Peer) LastSeen(r jid.Any) {
 	p.lockedResource = r.PotentialResource()
 }

--- a/session/mock/mocks.go
+++ b/session/mock/mocks.go
@@ -195,7 +195,7 @@ func (*SessionMock) SendDirTo(jid.Any, string, bool) *sdata.FileTransferControl 
 	return nil
 }
 
-// CurrentSymmetricKeyFor is the implementation for Session interface
+// CreateSymmetricKeyFor is the implementation for Session interface
 func (*SessionMock) CreateSymmetricKeyFor(jid.Any) []byte {
 	return nil
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?