### PR TITLE
Support tls-exporter channel binding on TLS >= 1.3

### DIFF
--- a/xmpp/tls.go
+++ b/xmpp/tls.go
@@ -119,7 +119,14 @@ func (d *dialer) startRawTLS(c interfaces.Conn, conn net.Conn) error {
 		return err
 	}
 
-	c.SetChannelBinding(tlsState.TLSUnique)
+	if tlsState.Version >= tls.VersionTLS13 {
+		ekm, err := tlsState.ExportKeyingMaterial("EXPORTER-Channel-Binding", nil, 32)
+		if err == nil {
+			c.SetChannelBinding(ekm)
+		}
+	} else {
+		c.SetChannelBinding(tlsState.TLSUnique)
+	}
 	d.bindTransport(c, tlsConn)
 
 	return nil


### PR DESCRIPTION
The upcoming [RFC 9266](https://www.rfc-editor.org/authors/rfc9266.html) (not yet published, but only minor editorial changes can be made at this point) will change the default channel binding type for TLS 1.3 (previously no channel bindings were defined and `-PLUS` SCRAM mechanisms were not available over TLS 1.3). This patch sets the new `tls-exporter` channel binding if the TLS version is >= 1.3 and uses the old `tls-unique` binding otherwise.