### PR TITLE
Fix building error caused by find_esc.sh

### DIFF
--- a/build/find_esc.sh
+++ b/build/find_esc.sh
@@ -2,11 +2,9 @@
 
 set -e
 
-found=0
+onpath=`which esc` || found=0
 
-onpath=`which esc`
-
-if [ -x $onpath ]; then
+if [ -x "$onpath" ]; then
     found=1
     cp $onpath $1/esc
 fi


### PR DESCRIPTION
Fixes a build error caused by find esc.sh when esc tool is not on the path