### PR TITLE
Add installation note for arch users

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ audit. This is worth keeping in mind if you are using CoyIM for something sensit
 Using CoyIM is very simple: you just need to download the executable file from the project's [home
 page](https://coy.im/) and then run it.
 
+**If you are using Arch Linux, you can install CoyIM via the [AUR](https://aur.archlinux.org/packages/coyim).**
+
 When you first launch CoyIM, a wizard will appear. If you already have a Jabber client installed and configured for OTR
 encryption in your computer, you can use this wizard to import your account settings as well as your OTR keys, and your
 contacts' fingerprints. By importing them, you won't have to do anything else to use CoyIM.


### PR DESCRIPTION
Coyim is available to be installed from the AUR, which allows it to better integrated into Arch Linux distribution instead of having to install the binary manually.

Add note to the installation section so that Arch Linux users are redirected to AUR.