### PR TITLE
CI: Bump Ubuntu Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -122,7 +122,7 @@ jobs:
   notify-test:
     name: Notify on success or failure of test
     needs: [test-linux, test-osx, test-win]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: always()
     steps:
       - name: checkout
@@ -146,7 +146,7 @@ jobs:
   build-release-linux:
     name: Build release (Linux)
     needs: test-linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: startsWith( github.ref, 'refs/tags/')
 
     steps:
@@ -384,7 +384,7 @@ jobs:
 
   create-release-from-tag:
     name: Create release from tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: startsWith( github.ref, 'refs/tags/v' )
     outputs:
       upload-url: ${{ steps.create_release.outputs.upload_url }}
@@ -404,7 +404,7 @@ jobs:
   upload-release-linux:
     name: Upload release (Linux)
     needs: [build-release-linux, create-release-from-tag]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/download-artifact@v2
@@ -440,7 +440,7 @@ jobs:
   upload-release-win:
     name: Upload release (Windows)
     needs: [build-release-win, build-windows-installer, create-release-from-tag]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/download-artifact@v2
@@ -487,7 +487,7 @@ jobs:
   upload-release-osx:
     name: Upload release (OS X)
     needs: [build-release-osx, create-release-from-tag]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Update CI Ubuntu version from 20.04 which is now EOL and deprecated, to Ubuntu 24.04