### PR TITLE
docs: add make deps in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ brew install gtk+3 gtk-mac-integration
 In order to build CoyIM, you should check out the source code, and run:
 
 ```sh
+make deps
 make build
 ```
 


### PR DESCRIPTION
```make deps``` is needed before ```make install```

currently, if user runs make install, they will receive error telling them to run ```make deps``` and try again, this avoids the extra step.